### PR TITLE
Fix addon-main.cjs missing in published npm package

### DIFF
--- a/ember-stargate/package.json
+++ b/ember-stargate/package.json
@@ -13,7 +13,7 @@
     "test": "tests"
   },
   "files": [
-    "addon-main.js",
+    "addon-main.cjs",
     "declarations",
     "dist"
   ],


### PR DESCRIPTION
Fixes #740 