### PR TITLE
fix deprecation: `Importing `inject` from `@ember/service` is deprecated.`

### DIFF
--- a/ember-stargate/src/components/portal-target.ts
+++ b/ember-stargate/src/components/portal-target.ts
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { modifier } from 'ember-modifier';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { assert } from '@ember/debug';
 import type PortalService from '../services/-portal';
 

--- a/ember-stargate/src/components/portal.ts
+++ b/ember-stargate/src/components/portal.ts
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { next } from '@ember/runloop';
 import { use, resource } from 'ember-resources';
 import type PortalService from '../services/-portal';


### PR DESCRIPTION
>Importing `inject` from `@ember/service` is deprecated. Please import `service` instead. [deprecation id: importing-inject-from-ember-service] This will be removed in ember-source 7.0.0. See https://deprecations.emberjs.com/id/importing-inject-from-ember-service for more details.
